### PR TITLE
fix(confirmationdialog): remove callback on deactivate dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relements",
-  "version": "2.2.0-develop.34",
+  "version": "2.2.0-develop.33",
   "description": "UI Components Library for React",
   "main": "build/bundle.umd.js",
   "module": "build/bundle.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relements",
-  "version": "2.2.0-develop.33",
+  "version": "2.2.0-develop.34",
   "description": "UI Components Library for React",
   "main": "build/bundle.umd.js",
   "module": "build/bundle.mjs",

--- a/src/decorators/ConfirmationDialog/ConfirmationDialog.js
+++ b/src/decorators/ConfirmationDialog/ConfirmationDialog.js
@@ -8,7 +8,7 @@ const ConfirmationDialog = () => WrappedComponent => {
   return props => {
     const [modalActive, setModalActive] = React.useState(false);
     const [modalContent, setModalContent] = React.useState({});
-    const confirmationCallback = React.useRef(() => {});
+    const confirmationCallback = React.useRef(null);
 
     const activateConfirmationDialog = React.useCallback(
       (modalContent = {}, callback) => {

--- a/src/decorators/ConfirmationDialog/ConfirmationDialog.js
+++ b/src/decorators/ConfirmationDialog/ConfirmationDialog.js
@@ -23,16 +23,17 @@ const ConfirmationDialog = () => WrappedComponent => {
         e.preventDefault();
         e.stopPropagation();
       }
+      confirmationCallback.current = null;
       setModalActive(false);
     });
 
     const deactivatePositive = React.useCallback(() => {
-      confirmationCallback.current(true);
+      if (confirmationCallback.current) confirmationCallback.current(true);
       deactivateConfirmationDialog();
     });
 
     const deactivateNegative = React.useCallback(() => {
-      confirmationCallback.current(false);
+      if (confirmationCallback.current) confirmationCallback.current(false);
       deactivateConfirmationDialog();
     });
 


### PR DESCRIPTION
Confirmationdialog is used as a decorator, so Modal component used inside is always mounted for any
wrapped component. Due to this, listeners to Modal component are not removed and are triggered
uneccessorily. One such example is onEnter callback is triggered even when the modal is not in
action. So, removing callback on deactivation.