### PR TITLE
fix(timepicker): selection wasnt proper, clearing the input error

### DIFF
--- a/src/components/Inputs/Time/__tests__/Time.test.js
+++ b/src/components/Inputs/Time/__tests__/Time.test.js
@@ -99,7 +99,7 @@ test("On Change", async () => {
     />,
   );
 
-  expect(tooltipInputHH.value).toBe("3");
+  expect(tooltipInputHH.value).toBe("03");
   expect(tooltipInputMM.value).toBe("10");
 
   fireEvent.mouseDown(inputElement);
@@ -108,7 +108,7 @@ test("On Change", async () => {
 
   expect(mockFn).toHaveBeenCalledTimes(2);
   const date2 = dayjs(mockFn.mock.calls[1][0]);
-  expect(date2.get("hour")).toBe(15);
+  expect(date2.get("hour")).toBe(3);
   expect(date2.get("minute")).toBe(10);
 
   rerender(
@@ -119,6 +119,6 @@ test("On Change", async () => {
     />,
   );
 
-  expect(tooltipInputHH.value).toBe("3");
+  expect(tooltipInputHH.value).toBe("03");
   expect(tooltipInputMM.value).toBe("10");
 });

--- a/src/components/Inputs/Time/components/TimePicker/TimePicker.js
+++ b/src/components/Inputs/Time/components/TimePicker/TimePicker.js
@@ -19,8 +19,15 @@ function TimePicker({ value, onChange, prefixClassName }) {
   const generateValue = React.useCallback(
     (newHH, newMM, newAMPM) => {
       let date = dayjs(value);
-      date = date.set("h", parseInt(newHH, 10) + (newAMPM === "PM" ? 12 : 0));
+      let hoursToAdd = 0;
+      if (newAMPM === "PM" && +newHH === 12) hoursToAdd = 0;
+      if (newAMPM === "AM" && +newHH === 12) hoursToAdd = 12;
+
+      date = date.set("h", parseInt(newHH, 10) + hoursToAdd);
       date = date.set("m", parseInt(newMM, 10));
+
+      if (dayjs(value).get("d") !== date.get("d"))
+        date = date.set("d", dayjs(value).get("d"));
 
       return date;
     },
@@ -29,14 +36,17 @@ function TimePicker({ value, onChange, prefixClassName }) {
 
   const handleHHChange = React.useCallback(
     e => {
-      const newHH = e.target ? e.target.value : e;
+      let newHH = e.target ? +e.target.value : e;
+      if (!newHH) newHH = 0;
       if (Number.isNaN(+newHH)) return;
       if (newHH > 12) return MMRef.current.focus();
       if (newHH > 1) {
         MMRef.current.select();
         MMRef.current.focus();
       }
+      if (newHH === 0) newHH = 12;
       if (newHH < 1) return;
+
       setHH(newHH);
       onChange(generateValue(newHH, MM, AMPM));
     },
@@ -45,7 +55,8 @@ function TimePicker({ value, onChange, prefixClassName }) {
 
   const handleMMChange = React.useCallback(
     e => {
-      const newMM = e.target ? e.target.value : e;
+      let newMM = e.target ? e.target.value : e;
+      if (!newMM) newMM = 0;
       if (Number.isNaN(+newMM)) return;
       if (newMM > 59) return;
       if (newMM < 0) return;

--- a/src/components/Inputs/Time/components/TimePickerInput/TimePickerInput.js
+++ b/src/components/Inputs/Time/components/TimePickerInput/TimePickerInput.js
@@ -14,15 +14,17 @@ function TimePickerInput({
   max,
 }) {
   const handleChange = React.useCallback(newValue => {
-    if (+newValue > max) onChange(0);
-    else onChange(newValue);
+    if (+newValue > max) onChange("00");
+    else onChange(`${newValue}`);
   });
+
+  const inputValue = +value > 9 ? `${+value}` : `0${+value}`;
 
   return (
     <div className={`${styles.timePickerInput} ${prefixClassName}`}>
       <input
         type="number"
-        value={value}
+        value={inputValue}
         onChange={e => handleChange(e.target.value)}
         ref={innerRef}
         className={`${prefixClassName}-element`}

--- a/src/components/Inputs/Time/components/TimePickerInput/TimePickerInput.js
+++ b/src/components/Inputs/Time/components/TimePickerInput/TimePickerInput.js
@@ -18,6 +18,8 @@ function TimePickerInput({
     else onChange(`${newValue}`);
   });
 
+  // in display we want to always show 2 digits 
+  // [1 should show up as 01, but 13 should show up as 13]
   const inputValue = +value > 9 ? `${+value}` : `0${+value}`;
 
   return (


### PR DESCRIPTION
- Date selection would break if the time input (hh/mm) was cleared
- It was counterintuitive to type
- When dealing with 12, PM and AM were reversed