### PR TITLE
fix(dropdown): blur called twice in athena

### DIFF
--- a/src/components/Inputs/Dropdown/Dropdown.js
+++ b/src/components/Inputs/Dropdown/Dropdown.js
@@ -109,6 +109,12 @@ const Dropdown = ({
     // 200 is a sufficiently high value
     // the delay is non-consequential as it's only there when the input resets
     setTimeout(() => {
+      console.error(
+        "BLUR::",
+        text !== firstValueLabel,
+        target,
+        blurCount.current,
+      );
       if (text !== firstValueLabel && target && blurCount.current === 1) {
         const optionIndex = dropdownOptions
           .map(option => option.label)

--- a/src/components/Inputs/Dropdown/Dropdown.js
+++ b/src/components/Inputs/Dropdown/Dropdown.js
@@ -109,12 +109,6 @@ const Dropdown = ({
     // 200 is a sufficiently high value
     // the delay is non-consequential as it's only there when the input resets
     setTimeout(() => {
-      console.error(
-        "BLUR::",
-        text !== firstValueLabel,
-        target,
-        blurCount.current,
-      );
       if (text !== firstValueLabel && target && blurCount.current === 1) {
         const optionIndex = dropdownOptions
           .map(option => option.label)

--- a/src/components/Inputs/Dropdown/components/Options/Options.js
+++ b/src/components/Inputs/Dropdown/components/Options/Options.js
@@ -104,7 +104,7 @@ const Options = ({
   return (
     <Portal>
       <div className={`${styles.dropdownOptionsWrapper}  ${className}`}>
-        <div className={styles.dropdownOptionsOverlay} onClick={onBlur} />
+        <div className={styles.dropdownOptionsOverlay} />
         <div
           ref={scrollContainer}
           style={{ ...position, ...focusedStyle }}


### PR DESCRIPTION
Weirdly does not happen on storybook. Clicking on the overlay was calling blur causing a double trigger