### PR TITLE
fix(File): FileExtenstionRefactorWithValidation #BB-2016

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,5 +130,10 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "husky": {
+    "hooks": {
+      "prepare-commit-msg": "npx exec < /dev/tty && git cz --hook || true"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -130,10 +130,5 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  },
-  "husky": {
-    "hooks": {
-      "prepare-commit-msg": "npx exec < /dev/tty && git cz --hook || true"
-    }
   }
 }

--- a/src/components/Inputs/File/File.js
+++ b/src/components/Inputs/File/File.js
@@ -281,8 +281,9 @@ class File extends React.Component {
   };
 
   _handleFile = e => {
-    const files = e.target.files;
-    if (!this._areFilesValid(files)) return;
+    const selectedFiles = e.target.files;
+    // Only upload valid files
+    const files = this._areFilesValid(selectedFiles);
     const filenames = [];
     const uploads = [...files].map((file, i) => {
       this._uploadFile(file, i, files.length);
@@ -348,25 +349,50 @@ class File extends React.Component {
   };
 
   _areFilesValid = files => {
-    let isValid = true;
+    // Validate the file and add them to the below arrays accordingly
+    const validFiles = [];
     const errorMessages = [];
+    const { type, maxFileSize } = this.props;
+
+    // Accepts the file extenstions and the selected file's type to validate
+    const fileValidation = (allowedFileTypes, file, fileType) => {
+      if (!allowedFileTypes.includes(fileType)) {
+        const errorMsg =
+          files.length > 1
+            ? "Some of the files selected are invalid."
+            : "Invalid File selected.";
+        errorMessages.push(
+          `${errorMsg} Supported formats: ${allowedFileTypes}`,
+        );
+      } else if (file.size > 1024 * 1024 * maxFileSize) {
+        errorMessages.push(
+          `File: ${file.name} must be less than ${maxFileSize}MB`,
+        );
+      } else {
+        validFiles.push(file);
+      }
+    };
+
     [...files].map(file => {
-      if (
-        this.props.type !== "file" &&
-        file.size > 1024 * 1024 * this.props.maxFileSize
-      ) {
-        errorMessages.push(
-          `File: ${file.name} must be less than ${this.props.maxFileSize}MB`,
-        );
-        isValid = false;
-      } else if (
-        this.props.type === "file" &&
-        file.size > 1024 * 1024 * this.props.maxFileSize
-      ) {
-        errorMessages.push(
-          `File: ${file.name} must be less than ${this.props.maxFileSize}MB`,
-        );
-        isValid = false;
+      // Image Extension Check
+      if (type === "image") {
+        const allowedImageTypes = IMAGE_ACCEPT_TYPES.split(", ");
+        fileValidation(allowedImageTypes, file, file.type);
+      }
+
+      // File Extenstions Check
+      else if (type === "file") {
+        const allowedFileTypes = FILE_ACCEPT_TYPES.split(", ");
+        fileValidation(allowedFileTypes, file, file.type);
+      }
+
+      // Custom Extenstions Check
+      else {
+        // Removed all the dots from the extensions to match the types with filetypes
+        const allowedTypes = type.replace(/\./g, "").split(", ");
+        const formattedFileType = file.type.split("/");
+        const fileType = formattedFileType[formattedFileType.length - 1];
+        fileValidation(allowedTypes, file, fileType);
       }
     });
 
@@ -374,7 +400,7 @@ class File extends React.Component {
       alert(errorMessages.join("\n"));
     }
 
-    return isValid;
+    return validFiles;
   };
 }
 

--- a/src/components/Inputs/File/File.js
+++ b/src/components/Inputs/File/File.js
@@ -283,7 +283,7 @@ class File extends React.Component {
   _handleFile = e => {
     const selectedFiles = e.target.files;
     // Only upload valid files
-    const files = this._areFilesValid(selectedFiles);
+    const files = this._getValidFiles(selectedFiles);
     const filenames = [];
     const uploads = [...files].map((file, i) => {
       this._uploadFile(file, i, files.length);
@@ -348,7 +348,7 @@ class File extends React.Component {
     );
   };
 
-  _areFilesValid = files => {
+  _getValidFiles = files => {
     // Validate the file and add them to the below arrays accordingly
     const validFiles = [];
     const errorMessages = [];

--- a/src/components/Inputs/File/__tests__/File.test.js
+++ b/src/components/Inputs/File/__tests__/File.test.js
@@ -186,3 +186,201 @@ test("Multiple test", async () => {
   const input = document.getElementsByClassName("test-input")[0];
   expect(input.multiple).toEqual(true);
 });
+
+//Extenstion Tests
+
+//#region Single File Upload Tests
+test("Single - Image Extension Test", async () => {
+  global.alert = jest.fn();
+  window.URL.createObjectURL = function() {};
+
+  //Invalid File
+  const invalidFile = new File(["dummy content"], "example.pdf", {
+    type: "application/pdf",
+  });
+
+  render(<FileComponent prefixClassName="test" type="image" />);
+  const input = document.getElementsByClassName("test-input")[0];
+
+  Object.defineProperty(input, "files", {
+    value: [invalidFile],
+    configurable: true,
+  });
+  fireEvent.change(input);
+
+  //Valid File
+  const validFile = new File(["dummy content"], "example.png", {
+    type: "image/png",
+  });
+
+  Object.defineProperty(input, "files", {
+    value: [validFile],
+  });
+  fireEvent.change(input);
+
+  expect(global.alert).toHaveBeenCalledTimes(1);
+});
+
+test("Single - File Extension Test", async () => {
+  global.alert = jest.fn();
+  window.URL.createObjectURL = function() {};
+
+  //Invalid File
+  const invalidFile = new File(["dummy content"], "example.exe", {
+    type: "application/octet-stream",
+  });
+
+  render(<FileComponent prefixClassName="test" type="file" />);
+  const input = document.getElementsByClassName("test-input")[0];
+
+  Object.defineProperty(input, "files", {
+    value: [invalidFile],
+    configurable: true,
+  });
+  fireEvent.change(input);
+
+  //Valid File
+  const validFile = new File(["dummy content"], "example.png", {
+    type: "image/png",
+  });
+
+  Object.defineProperty(input, "files", {
+    value: [validFile],
+  });
+  fireEvent.change(input);
+
+  expect(global.alert).toHaveBeenCalledTimes(1);
+});
+
+test("Single - Custom Extension Test", async () => {
+  global.alert = jest.fn();
+  window.URL.createObjectURL = function() {};
+
+  //Invalid File
+  const invalidFile = new File(["dummy content"], "example.exe", {
+    type: "application/octet-stream",
+  });
+
+  const { rerender } = render(
+    <FileComponent prefixClassName="test" type=".png, .pdf" />,
+  );
+  const input = document.getElementsByClassName("test-input")[0];
+
+  Object.defineProperty(input, "files", {
+    value: [invalidFile],
+    configurable: true,
+  });
+  fireEvent.change(input);
+
+  //Valid File
+  const validFile = new File(["dummy content"], "example.png", {
+    type: "image/png",
+  });
+
+  Object.defineProperty(input, "files", {
+    value: [validFile],
+  });
+  fireEvent.change(input);
+
+  //Mixed
+  const mixed = new File(["dummy content"], "example.png", {
+    type: "image/png",
+  });
+  rerender(<FileComponent prefixClassName="test" type=".png, .asdw" />);
+
+  Object.defineProperty(input, "files", {
+    value: [mixed],
+  });
+  fireEvent.change(input);
+
+  expect(global.alert).toHaveBeenCalledTimes(1);
+});
+//#endregion
+
+//#region Multiple File Upload Tests
+test("Multiple - Image Extension Test", async () => {
+  global.alert = jest.fn();
+  window.URL.createObjectURL = function() {};
+
+  const imgFile = new File(["dummy content"], "example.png", {
+    type: "image/png",
+  });
+
+  const invalidFile = new File(["dummy content"], "example.exe", {
+    type: "application/octet-stream",
+  });
+
+  render(<FileComponent prefixClassName="test" type="image" multiple={true} />);
+
+  const multipleInput = document.getElementsByClassName("test-input")[0];
+
+  Object.defineProperty(multipleInput, "files", {
+    value: [imgFile, invalidFile],
+  });
+  fireEvent.change(multipleInput);
+
+  expect(global.alert).toHaveBeenCalledTimes(1);
+});
+
+test("Multiple - File Extension Test", async () => {
+  global.alert = jest.fn();
+  window.URL.createObjectURL = function() {};
+
+  const imgFile = new File(["dummy content"], "example.png", {
+    type: "image/png",
+  });
+
+  const file = new File(["dummy content"], "example.jpg", {
+    type: "image/jpg",
+  });
+
+  const invalidFile = new File(["dummy content"], "example.exe", {
+    type: "application/octet-stream",
+  });
+
+  render(<FileComponent prefixClassName="test" type="file" multiple={true} />);
+
+  const multipleInput = document.getElementsByClassName("test-input")[0];
+
+  Object.defineProperty(multipleInput, "files", {
+    value: [imgFile, file, invalidFile],
+  });
+  fireEvent.change(multipleInput);
+
+  expect(global.alert).toHaveBeenCalledTimes(1);
+});
+
+test("Multiple - Custom Extension Test", async () => {
+  global.alert = jest.fn();
+  window.URL.createObjectURL = function() {};
+
+  const imgFile = new File(["dummy content"], "example.png", {
+    type: "image/png",
+  });
+
+  const file = new File(["dummy content"], "example.jpg", {
+    type: "image/jpg",
+  });
+
+  const invalidFile = new File(["dummy content"], "example.exe", {
+    type: "application/octet-stream",
+  });
+
+  render(
+    <FileComponent
+      prefixClassName="test"
+      type=".png, .jpg, .pdf"
+      multiple={true}
+    />,
+  );
+
+  const multipleInput = document.getElementsByClassName("test-input")[0];
+
+  Object.defineProperty(multipleInput, "files", {
+    value: [imgFile, file, invalidFile],
+  });
+  fireEvent.change(multipleInput);
+
+  expect(global.alert).toHaveBeenCalledTimes(1);
+});
+//#endregion


### PR DESCRIPTION
Refactored the validation logic of File.js component. 
 - The component now does not allow files to be uploaded which are different from specified types in its props.

e.g. If the component has prop `type = "image"`, then only files with image extensions will be allowed to upload, if selected anything other than that, an error will popup showing the necessary extensions for that respective component.

Types allowed:
1. **`image`** - "image/png, image/jpg, image/jpeg"
2. **`file`** - "image/png, image/jpg, image/jpeg, application/pdf, application/ vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword"
3. Custom extensions in the following format - **`.png, .jpg`**, etc.
 
