### PR TITLE
fix(file): change image type jpg to jpeg for type comparison

### DIFF
--- a/src/components/Inputs/File/File.js
+++ b/src/components/Inputs/File/File.js
@@ -18,8 +18,8 @@ import ImageProgressBar from "./components/ImageProgressBar";
 
 const FILE_ACCEPT_TYPES =
   // eslint-disable-next-line max-len
-  "image/png, image/jpg, image/jpeg, application/pdf, application/ vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword";
-const IMAGE_ACCEPT_TYPES = "image/png, image/jpg, image/jpeg";
+  "image/png, image/jpeg, application/pdf, application/ vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword";
+const IMAGE_ACCEPT_TYPES = "image/png, image/jpeg";
 
 class File extends React.Component {
   _newUploadItem = {
@@ -438,7 +438,7 @@ File.defaultProps = {
   baseWidth: 290,
   className: "",
   prefixClassName: "",
-  type: ".png, .jpg",
+  type: ".png, .jpeg",
   dimensions: "450px X 450px",
   maxFileSize: 5,
 };

--- a/src/components/Inputs/File/__tests__/File.test.js
+++ b/src/components/Inputs/File/__tests__/File.test.js
@@ -331,7 +331,7 @@ test("Multiple - File Extension Test", async () => {
   });
 
   const file = new File(["dummy content"], "example.jpg", {
-    type: "image/jpg",
+    type: "image/jpeg",
   });
 
   const invalidFile = new File(["dummy content"], "example.exe", {
@@ -359,7 +359,7 @@ test("Multiple - Custom Extension Test", async () => {
   });
 
   const file = new File(["dummy content"], "example.jpg", {
-    type: "image/jpg",
+    type: "image/jpeg",
   });
 
   const invalidFile = new File(["dummy content"], "example.exe", {
@@ -369,7 +369,7 @@ test("Multiple - Custom Extension Test", async () => {
   render(
     <FileComponent
       prefixClassName="test"
-      type=".png, .jpg, .pdf"
+      type=".png, .jpeg, .pdf"
       multiple={true}
     />,
   );


### PR DESCRIPTION
jpg is not an image type it's just a file extension for the jpeg image type.
https://www.keycdn.com/support/difference-between-jpg-and-jpeg
Replace image type `jpg` to `jpeg` in the file validation code.

we should also change the type prop from string to array as a breaking change later.
the new allowed types props should contain list of types allowed.
![image](https://user-images.githubusercontent.com/11783611/83642131-11df9c00-a5cc-11ea-8233-e753e148e55e.png)



