### PR TITLE
fix(file): fix test cases for image/jpeg types

### DIFF
--- a/src/components/Inputs/File/__tests__/File.test.js
+++ b/src/components/Inputs/File/__tests__/File.test.js
@@ -395,7 +395,7 @@ test("Multiple - Custom Extension Test", async () => {
   render(
     <FileComponent
       prefixClassName="test"
-      type=".png, .jpg, .pdf"
+      type=".png, .jpeg, .pdf"
       multiple={true}
       onError={error}
     />,

--- a/src/components/Inputs/File/__tests__/File.test.js
+++ b/src/components/Inputs/File/__tests__/File.test.js
@@ -350,7 +350,7 @@ test("Multiple - File Extension Test", async () => {
   });
 
   const file = new File(["dummy content"], "example.jpg", {
-    type: "image/jpg",
+    type: "image/jpeg",
   });
 
   const invalidFile = new File(["dummy content"], "example.exe", {
@@ -385,7 +385,7 @@ test("Multiple - Custom Extension Test", async () => {
   });
 
   const file = new File(["dummy content"], "example.jpg", {
-    type: "image/jpg",
+    type: "image/jpeg",
   });
 
   const invalidFile = new File(["dummy content"], "example.exe", {


### PR DESCRIPTION
Changelog
1. Update `image/jpg` to `image/jpeg` in test cases for file extension.
2. Fix the `.jpeg` prop type for custom extensions.