### PR TITLE
fix(file): extension fix to identify csv files for windows

### DIFF
--- a/src/components/Inputs/File/File.js
+++ b/src/components/Inputs/File/File.js
@@ -455,8 +455,8 @@ class File extends React.Component {
         if (allowedTypes.includes("csv")) {
           allowedTypes.push("vnd.ms-excel");
 
-          if (fileType === "") {
-            fileType = "text/csv";
+          if (fileType === "" && file.name.includes(".csv")) {
+            fileType = "csv";
           }
         }
 

--- a/src/components/Inputs/File/File.js
+++ b/src/components/Inputs/File/File.js
@@ -414,10 +414,12 @@ class File extends React.Component {
     // Accepts the file extenstions and the selected file's type to validate
     const fileValidation = (allowedFileTypes, file, fileType) => {
       // TEMPORARY FIX: Windows may/may not identify file type for csv files
+      // TODO: Find a permenant solution for this issue
+
       const validFileTypeCheck =
         fileType !== ""
           ? !allowedFileTypes.includes(fileType)
-          : file.name.split(".")[1] !== "csv";
+          : !file.name.includes(".csv");
 
       if (validFileTypeCheck) {
         const errorMsg =

--- a/src/components/Inputs/File/File.js
+++ b/src/components/Inputs/File/File.js
@@ -413,15 +413,7 @@ class File extends React.Component {
 
     // Accepts the file extenstions and the selected file's type to validate
     const fileValidation = (allowedFileTypes, file, fileType) => {
-      // TEMPORARY FIX: Windows may/may not identify file type for csv files
-      // TODO: Find a permenant solution for this issue
-
-      const validFileTypeCheck =
-        fileType !== ""
-          ? !allowedFileTypes.includes(fileType)
-          : !file.name.includes(".csv");
-
-      if (validFileTypeCheck) {
+      if (!allowedFileTypes.includes(fileType)) {
         const errorMsg =
           files.length > 1
             ? "Some of the files selected are invalid."
@@ -456,7 +448,18 @@ class File extends React.Component {
         // Removed all the dots from the extensions to match the types with filetypes
         const allowedTypes = type.replace(/\./g, "").split(", ");
         const formattedFileType = file.type.split("/");
-        const fileType = formattedFileType[formattedFileType.length - 1];
+        let fileType = formattedFileType[formattedFileType.length - 1];
+
+        // TEMPORARY FIX: Windows may/may not identify file type for csv files
+        // TODO: Find a permenant solution for this issue
+        if (allowedTypes.includes("csv")) {
+          allowedTypes.push("vnd.ms-excel");
+
+          if (fileType === "") {
+            fileType = "text/csv";
+          }
+        }
+
         fileValidation(allowedTypes, file, fileType);
       }
     });

--- a/src/components/Inputs/File/File.js
+++ b/src/components/Inputs/File/File.js
@@ -418,11 +418,8 @@ class File extends React.Component {
           ? "Some of the files selected are invalid."
           : "Invalid File selected.";
 
-      if (customValidate) {
-        const isValid = customValidate(allowedFileTypes, file, fileType);
-        if (!isValid) {
-          errorMessages.push(errorMsg);
-        }
+      if (customValidate && !customValidate(allowedFileTypes, file, fileType)) {
+        errorMessages.push(errorMsg);
       } else if (!allowedFileTypes.includes(fileType)) {
         errorMessages.push(
           `${errorMsg} Supported formats: ${allowedFileTypes}`,

--- a/src/components/Inputs/File/File.js
+++ b/src/components/Inputs/File/File.js
@@ -19,7 +19,7 @@ import ImageProgressBar from "./components/ImageProgressBar";
 
 const FILE_ACCEPT_TYPES =
   // eslint-disable-next-line max-len
-  "image/png, image/jpeg, application/pdf, application/ vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword";
+  "image/png, image/jpeg, application/pdf, application/ vnd.openxmlformats-officedocument.wordprocessingml.document, application/msword, text/csv, application/vnd.ms-excel";
 const IMAGE_ACCEPT_TYPES = "image/png, image/jpeg";
 
 @ToastMessage()
@@ -413,7 +413,13 @@ class File extends React.Component {
 
     // Accepts the file extenstions and the selected file's type to validate
     const fileValidation = (allowedFileTypes, file, fileType) => {
-      if (!allowedFileTypes.includes(fileType)) {
+      // TEMPORARY FIX: Windows may/may not identify file type for csv files
+      const validFileTypeCheck =
+        fileType !== ""
+          ? !allowedFileTypes.includes(fileType)
+          : file.name.split(".")[1] !== "csv";
+
+      if (validFileTypeCheck) {
         const errorMsg =
           files.length > 1
             ? "Some of the files selected are invalid."

--- a/src/components/Inputs/File/File.mdx
+++ b/src/components/Inputs/File/File.mdx
@@ -53,6 +53,10 @@ import File from "./File";
   <File type="image/png" />
 </CodeBlock>
 
+<CodeBlock title="Type: Custom Extension">
+  <File type=".csv" />
+</CodeBlock>
+
 <CodeBlock title="Type: Value & Ratio already present">
   <File value="test.jpg" ratio="1.1" />
 </CodeBlock>

--- a/src/components/Inputs/File/File.mdx
+++ b/src/components/Inputs/File/File.mdx
@@ -61,11 +61,7 @@ import File from "./File";
   <File
     type=".csv"
     customValidate={(allowedFileTypes, file, fileType) => {
-      let isValid;
-      if (allowedFileTypes.includes("csv")) {
-        allowedFileTypes.push("vnd.ms-excel");
-      }
-      isValid = file.name.includes(".csv");
+      let isValid = file.name.includes(".csv");
       return isValid;
     }}
   />

--- a/src/components/Inputs/File/File.mdx
+++ b/src/components/Inputs/File/File.mdx
@@ -57,6 +57,20 @@ import File from "./File";
   <File type=".csv" />
 </CodeBlock>
 
+<CodeBlock title="Type: Custom Validate">
+  <File
+    type=".csv"
+    customValidate={(allowedFileTypes, file, fileType) => {
+      let isValid;
+      if (allowedFileTypes.includes("csv")) {
+        allowedFileTypes.push("vnd.ms-excel");
+      }
+      isValid = file.name.includes(".csv");
+      return isValid;
+    }}
+  />
+</CodeBlock>
+
 <CodeBlock title="Type: Value & Ratio already present">
   <File value="test.jpg" ratio="1.1" />
 </CodeBlock>

--- a/src/components/Inputs/File/__tests__/File.test.js
+++ b/src/components/Inputs/File/__tests__/File.test.js
@@ -465,3 +465,23 @@ test("On Upload test", async () => {
   fireEvent.change(input);
   expect(onUpload).toHaveBeenCalled();
 });
+
+test("Custom Validate test", async () => {
+  const customValidate = jest.fn();
+  const file = new File(["dummy content"], "example.png", {
+    type: "image/png",
+  });
+
+  render(
+    <FileComponent prefixClassName="test" customValidate={customValidate} />,
+  );
+
+  const input = document.getElementsByClassName("test-input")[0];
+
+  Object.defineProperty(input, "files", {
+    value: [file],
+  });
+
+  fireEvent.change(input);
+  expect(customValidate).toHaveBeenCalled();
+});


### PR DESCRIPTION
Ticket: [BB-2379](https://hello-haptik.atlassian.net/browse/BB-2379)

## Note
- Temporary fix for Windows machines where they may or may not identify the file type of csv files.
Ref: https://stackoverflow.com/questions/51724649/mime-type-of-file-returning-empty-in-javascript-on-some-machines

## Todo
- Find a permanent solution to address this issue