### PR TITLE
improvement(rangePicker): add max/min date support to range-picker

### DIFF
--- a/src/components/Inputs/Date/Date.mdx
+++ b/src/components/Inputs/Date/Date.mdx
@@ -41,8 +41,6 @@ import Date from "./Date";
       onChange={onChange}
       numMonths={2}
       withRange
-      maxDate={dayjs().add(7, "d")}
-      minDate={dayjs().subtract(30, "d")}
     />
   )}
 </CodeBlock>
@@ -59,6 +57,24 @@ import Date from "./Date";
       numMonths={2}
       withRange
       withComparison
+      position="TOP"
+    />
+  )}
+</CodeBlock>
+
+<CodeBlock
+  title="Minimum/Maximum Selectable Dates"
+  defaultValue={{ startDate: dayjs(), endDate: dayjs().add(7, "d") }}
+>
+  {(value, onChange) => (
+    <Date
+      label="Select Date"
+      value={value}
+      onChange={onChange}
+      numMonths={2}
+      withRange
+      maxDate={dayjs().add(7, "d")}
+      minDate={dayjs().subtract(30, "d")}
       position="TOP"
     />
   )}

--- a/src/components/Inputs/Date/Date.mdx
+++ b/src/components/Inputs/Date/Date.mdx
@@ -59,6 +59,7 @@ import Date from "./Date";
       numMonths={2}
       withRange
       withComparison
+      position="TOP"
     />
   )}
 </CodeBlock>

--- a/src/components/Inputs/Date/Date.mdx
+++ b/src/components/Inputs/Date/Date.mdx
@@ -8,7 +8,13 @@ import Date from "./Date";
 
 <CodeBlock defaultValue={dayjs()}>
   {(value, onChange) => (
-    <Date label="Select Date" value={value} onChange={onChange} numMonths={2} withTime/>
+    <Date
+      label="Select Date"
+      value={value}
+      onChange={onChange}
+      numMonths={2}
+      withTime
+    />
   )}
 </CodeBlock>
 
@@ -35,6 +41,7 @@ import Date from "./Date";
       onChange={onChange}
       numMonths={2}
       withRange
+      maxDate={dayjs().add(7, "d")}
     />
   )}
 </CodeBlock>

--- a/src/components/Inputs/Date/Date.mdx
+++ b/src/components/Inputs/Date/Date.mdx
@@ -42,6 +42,7 @@ import Date from "./Date";
       numMonths={2}
       withRange
       maxDate={dayjs().add(7, "d")}
+      minDate={dayjs().subtract(30, "d")}
     />
   )}
 </CodeBlock>

--- a/src/components/Inputs/Date/Date.mdx
+++ b/src/components/Inputs/Date/Date.mdx
@@ -63,7 +63,39 @@ import Date from "./Date";
 </CodeBlock>
 
 <CodeBlock
-  title="Minimum/Maximum Selectable Dates"
+  title="Minimum Selectable Dates"
+  defaultValue={{ startDate: dayjs(), endDate: dayjs().add(7, "d") }}
+>
+  {(value, onChange) => (
+    <Date
+      label="Select Date"
+      value={value}
+      onChange={onChange}
+      numMonths={2}
+      withRange
+      minDate={dayjs().subtract(30, "d")}
+    />
+  )}
+</CodeBlock>
+<CodeBlock
+  title="Maximum Selectable Dates"
+  defaultValue={{ startDate: dayjs(), endDate: dayjs().add(7, "d") }}
+>
+  {(value, onChange) => (
+    <Date
+      label="Select Date"
+      value={value}
+      onChange={onChange}
+      numMonths={2}
+      withRange
+      maxDate={dayjs().add(7, "d")}
+      position="TOP"
+    />
+  )}
+</CodeBlock>
+
+<CodeBlock
+  title="Minimum & Maximum Selectable Dates"
   defaultValue={{ startDate: dayjs(), endDate: dayjs().add(7, "d") }}
 >
   {(value, onChange) => (

--- a/src/components/Inputs/Date/__tests__/Date.basic.test.js
+++ b/src/components/Inputs/Date/__tests__/Date.basic.test.js
@@ -34,6 +34,8 @@ const Component = ({
   withComparison,
   disabled,
   error,
+  maxDate,
+  minDate,
   label = "Enter date",
 }) => (
   <Date
@@ -45,6 +47,8 @@ const Component = ({
     numMonths={numMonths}
     withRange={withRange}
     withComparison={withComparison}
+    maxDate={maxDate}
+    minDate={minDate}
     disabled={disabled}
     error={error}
     withTime

--- a/src/components/Inputs/Date/__tests__/Date.basic.test.js
+++ b/src/components/Inputs/Date/__tests__/Date.basic.test.js
@@ -133,6 +133,48 @@ test("max date, min date", async () => {
   );
 });
 
+test("min date", async () => {
+  const mockFn = jest.fn();
+  render(
+    <Component
+      value={{
+        startDate: dayjs().toDate(),
+        endDate: dayjs()
+          .add(1, "d")
+          .toDate(),
+      }}
+      prefixClassName="test"
+      onChange={mockFn}
+      withRange
+      withComparison
+      numCalender
+      minDate={dayjs().toDate()}
+    />,
+  );
+});
+
+test("max date", async () => {
+  const mockFn = jest.fn();
+  render(
+    <Component
+      value={{
+        startDate: dayjs().toDate(),
+        endDate: dayjs()
+          .add(1, "d")
+          .toDate(),
+      }}
+      prefixClassName="test"
+      onChange={mockFn}
+      withRange
+      withComparison
+      numCalender
+      maxDate={dayjs()
+        .add(1, "d")
+        .toDate()}
+    />,
+  );
+});
+
 test("On Comparison Toggle", async () => {
   const mockFn = jest.fn();
   render(

--- a/src/components/Inputs/Date/__tests__/Date.basic.test.js
+++ b/src/components/Inputs/Date/__tests__/Date.basic.test.js
@@ -110,6 +110,29 @@ test("Prefix class", async () => {
   });
 });
 
+test("max date, min date", async () => {
+  const mockFn = jest.fn();
+  render(
+    <Component
+      value={{
+        startDate: dayjs().toDate(),
+        endDate: dayjs()
+          .add(1, "d")
+          .toDate(),
+      }}
+      prefixClassName="test"
+      onChange={mockFn}
+      withRange
+      withComparison
+      numCalender
+      maxDate={dayjs()
+        .add(1, "d")
+        .toDate()}
+      minDate={dayjs().toDate()}
+    />,
+  );
+});
+
 test("On Comparison Toggle", async () => {
   const mockFn = jest.fn();
   render(

--- a/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
+++ b/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
@@ -217,8 +217,8 @@ RangePicker.defaultProps = {
   withComparison: false,
   numMonths: 2,
   prefixClassName: "",
-  maxDate: dayjs(),
-  minDate: dayjs(),
+  maxDate: null,
+  minDate: null,
   value: {
     startDate: dayjs(),
     endDate: dayjs(),

--- a/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
+++ b/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
@@ -203,8 +203,8 @@ RangePicker.propTypes = {
   withComparison: PropTypes.bool,
   prefixClassName: PropTypes.string,
   numMonths: PropTypes.number,
-  maxDate: PropTypes.object,
-  minDate: PropTypes.object,
+  maxDate: PropTypes.instanceOf(Date),
+  minDate: PropTypes.instanceOf(Date),
   value: PropTypes.shape({
     startDate: PropTypes.object,
     endDate: PropTypes.object,

--- a/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
+++ b/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
@@ -44,7 +44,7 @@ export default class RangePicker extends React.Component {
       });
     }
 
-    const { prefixClassName, numMonths } = this.props;
+    const { prefixClassName, numMonths, maxDate, minDate } = this.props;
 
     return (
       <div className={`${styles.rangePicker} ${prefixClassName}`}>
@@ -55,6 +55,8 @@ export default class RangePicker extends React.Component {
             value={value}
             onChange={this._handleCellClick}
             numMonths={numMonths}
+            maxDate={maxDate}
+            minDate={minDate}
             prefixClassName={`${prefixClassName}-calendar`}
           />
         </div>
@@ -201,6 +203,8 @@ RangePicker.propTypes = {
   withComparison: PropTypes.bool,
   prefixClassName: PropTypes.string,
   numMonths: PropTypes.number,
+  maxDate: PropTypes.object,
+  minDate: PropTypes.object,
   value: PropTypes.shape({
     startDate: PropTypes.object,
     endDate: PropTypes.object,
@@ -213,6 +217,8 @@ RangePicker.defaultProps = {
   withComparison: false,
   numMonths: 2,
   prefixClassName: "",
+  maxDate: dayjs(),
+  minDate: dayjs(),
   value: {
     startDate: dayjs(),
     endDate: dayjs(),


### PR DESCRIPTION
## JIRA TICKET : [1150](https://hello-haptik.atlassian.net/browse/AN-1150)
## Demo Link: [Storybook](https://604b209acbb07e0007155079--elastic-kare-88bfa0.netlify.app/?path=/story/components-inputs-date--documentation) 
To allow disabling dates after current date in Analytics
Added max and min selectable dates in date range picker