### PR TITLE
fix(calendar): default props, comparison date format to dayjs

### DIFF
--- a/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
+++ b/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
@@ -143,8 +143,9 @@ export default class RangePicker extends React.Component {
       const { startDate, endDate } = this.state;
       const numDays = endDate && endDate.diff(startDate, "d");
       const compMaxDate =
-        comparisonMaxDate && comparisonMaxDate.isBefore(day.add(numDays, "d"))
-          ? comparisonMaxDate
+        comparisonMaxDate &&
+        dayjs(comparisonMaxDate).isBefore(day.add(numDays, "d"))
+          ? dayjs(comparisonMaxDate)
           : day.add(numDays, "d");
       this.setState({
         selectingKey: "comparisonStartDate",

--- a/src/components/UI/Calendar/Calendar.js
+++ b/src/components/UI/Calendar/Calendar.js
@@ -341,9 +341,9 @@ Calendar.defaultProps = {
   mergeColor: "#F00",
   className: "",
   prefixClassName: "",
-  minDate: undefined,
-  maxDate: undefined,
-  comparisonMaxDate: undefined,
+  minDate: null,
+  maxDate: null,
+  comparisonMaxDate: null,
   toggled: false,
 };
 


### PR DESCRIPTION
### JIRA Ticket

Jira:  [1150](https://hello-haptik.atlassian.net/browse/AN-1150)
--
### DEMO: [Link](https://vibrant-leavitt-fb790f.netlify.app/?path=/story/components-inputs-date--documentation) 

### Changelog

Fixed default props in calendar, changed comparisonDate format using dayjs