### PR TITLE
fix(calendar): prevent unnecessary month toggles in calendar

### DIFF
--- a/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
+++ b/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
@@ -69,8 +69,6 @@ export default class RangePicker extends React.Component {
             minDate={minDate}
             toggled={this.state.compare}
             comparisonMaxDate={comparisonMaxDate}
-            comparisonEndDate={comparisonEndDate}
-            comparisonStartDate={comparisonStartDate}
             prefixClassName={`${prefixClassName}-calendar`}
           />
         </div>

--- a/src/components/UI/Calendar/Calendar.js
+++ b/src/components/UI/Calendar/Calendar.js
@@ -231,29 +231,19 @@ const Calendar = ({
   toggled,
   startDate,
   endDate,
-  comparisonEndDate,
-  comparisonStartDate,
 }) => {
   const ranges = Array.isArray(value) ? value : [{ from: value, to: value }];
   const [viewingMonth, setViewingMonth] = React.useState(dayjs());
 
   React.useEffect(() => {
-    toggleMonth(startDate, endDate);
-  }, [endDate]);
-
-  React.useEffect(() => {
-    toggleMonth(comparisonStartDate, comparisonEndDate);
-  }, [comparisonEndDate]);
-
-  const toggleMonth = (start, end) => {
-    start &&
-      end &&
+    startDate &&
+      endDate &&
       viewingMonth.format("M") !==
-        dayjs(end)
+        dayjs(endDate)
           .add(1, "month")
           .format("M") &&
-      setViewingMonth(end);
-  };
+      setViewingMonth(endDate);
+  }, [endDate]);
 
   const viewNextMonth = React.useCallback(() => {
     setViewingMonth(viewingMonth.add(1, "month"));
@@ -320,10 +310,6 @@ Calendar.propTypes = {
   startDate: PropTypes.string,
   /** end date of the range* */
   endDate: PropTypes.string,
-  /** start date of the range * */
-  comparisonStartDate: PropTypes.string,
-  /** end date of the range* */
-  comparisonEndDate: PropTypes.string,
   /** Dates after this date would be disabled * */
   maxDate: PropTypes.string,
   /** Dates before this date would be disabled * */


### PR DESCRIPTION
### JIRA Ticket

Jira:  [1150](https://hello-haptik.atlassian.net/browse/AN-1150)

 ### Demo Link
Demo: [Link](https://605423a72d0e500007215411--practical-boyd-52c19d.netlify.app/?path=/story/components-inputs-date--documentation)

### Changes
 - prevent unnecessary month toggles in calendar
 - removed top border from start and end dates
 