### PR TITLE
fix(range picker): default end date value if not selected

### DIFF
--- a/src/components/Inputs/Date/__tests__/Date.basic.test.js
+++ b/src/components/Inputs/Date/__tests__/Date.basic.test.js
@@ -175,6 +175,22 @@ test("max date", async () => {
   );
 });
 
+test("only start date selected", async () => {
+  const mockFn = jest.fn();
+  render(
+    <Component
+      value={{
+        startDate: dayjs().toDate(),
+      }}
+      prefixClassName="test"
+      onChange={mockFn}
+      withRange
+      withComparison
+      numCalender
+    />,
+  );
+});
+
 test("On Comparison Toggle", async () => {
   const mockFn = jest.fn();
   render(

--- a/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
+++ b/src/components/Inputs/Date/components/RangeComparison/RangePicker.js
@@ -115,7 +115,7 @@ export default class RangePicker extends React.Component {
     } = this.state;
     return {
       startDate: startDate ? startDate.startOf("day").toDate() : startDate,
-      endDate: endDate ? endDate.endOf("day").toDate() : null,
+      endDate: endDate ? endDate.endOf("day").toDate() : startDate,
       comparisonStartDate: comparisonStartDate
         ? comparisonStartDate.startOf("day").toDate()
         : null,


### PR DESCRIPTION
### JIRA Ticket
[JIRA](https://hello-haptik.atlassian.net/browse/AN-1540)

### Changelog

- On selecting start date and clicking outside, end date becomes invalid. 
- If end date is not selected, default end date now is the start date.

### Testing
 [Link](https://605c50926ed7a382307ae62c--jovial-yalow-c75e76.netlify.app/?path=/story/components-inputs-date--documentation)