### PR TITLE
fix(withtooltip): change default value of tooltip to null

### DIFF
--- a/src/components/Overlays/WithTooltip/WithTooltip.js
+++ b/src/components/Overlays/WithTooltip/WithTooltip.js
@@ -54,7 +54,7 @@ function WithTooltip({
       className={`${styles.withTooltipWrapper} ${className} ${prefixClassName}`}
     >
       {children}
-      {tooltip && (
+      {tooltip !== null && (
         <Tooltip {...withTooltipProps}>
           <div className={tooltipContentClassName}>{tooltip}</div>
         </Tooltip>
@@ -76,7 +76,7 @@ WithTooltip.propTypes = {
 WithTooltip.defaultProps = {
   children: null,
   className: "",
-  tooltip: "",
+  tooltip: null,
   position: "TOP",
   disabled: false,
   onClick: () => {},


### PR DESCRIPTION
### JIRA Ticket

Jira:  [AGT-1147](https://hello-haptik.atlassian.net/browse/AGCT-1147)

--

### Changelog

- change the default value of tooltip to null to indicate the absence of value, 
- the absence of value should be checked to decide whether or not to render the tooltip

-- Before
![image](https://user-images.githubusercontent.com/11783611/113271872-9daf7b00-92f8-11eb-8cf8-cafe9473492d.png)

-- After
![image](https://user-images.githubusercontent.com/11783611/113271896-a4d68900-92f8-11eb-962d-31ecc4742fde.png)

