### PR TITLE
Revert "fix(withtooltip): change default value of tooltip to null (#466)"

### DIFF
--- a/src/components/Overlays/WithTooltip/WithTooltip.js
+++ b/src/components/Overlays/WithTooltip/WithTooltip.js
@@ -54,7 +54,7 @@ function WithTooltip({
       className={`${styles.withTooltipWrapper} ${className} ${prefixClassName}`}
     >
       {children}
-      {tooltip !== null && (
+      {tooltip && (
         <Tooltip {...withTooltipProps}>
           <div className={tooltipContentClassName}>{tooltip}</div>
         </Tooltip>
@@ -76,7 +76,7 @@ WithTooltip.propTypes = {
 WithTooltip.defaultProps = {
   children: null,
   className: "",
-  tooltip: null,
+  tooltip: "",
   position: "TOP",
   disabled: false,
   onClick: () => {},


### PR DESCRIPTION
### JIRA Ticket

Jira:  [AGCT-1152](https://hello-haptik.atlassian.net/browse/AGCT-1152)

### Changelog

- This reverts commit 73500e83a32c19ed18453c7d9ebfe9d6e9984447.
- Making this change is hard right now since a lot of our code depends on the default value as an empty string. converting it to null would require a lot of code changes. We probably need to rethink our approach for the absence of value indication.
