### PR TITLE
build(travis): update node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Tells Travis we're running on a Node environment
 language: node_js
-node_js: "10"
+node_js: "10.22.0"
 cache: yarn
 
 install:


### PR DESCRIPTION
### JIRA Ticket

Jira:  [AGCT-1343](https://hello-haptik.atlassian.net/browse/AGCT-1343)

--

### Changelog

Travis uses NodeJs version 10.
Required Nodejs version on Relements is 10.22, or greater.
It might create problems in the future so better be on correct versions.